### PR TITLE
fix storage to h5 before solve call

### DIFF
--- a/python/triqs_hubbardI/solver.py
+++ b/python/triqs_hubbardI/solver.py
@@ -203,35 +203,39 @@ class Solver():
 
 
     def __reduce_to_dict__(self):
-       return {'G0_w': self.G0_w, 'G0_iw': self.G0_iw,'G_tau': self.G_tau,
-               'G_l': self.G_l, 'Sigma_iw': self.Sigma_iw, 'G_iw': self.G_iw,
-               'Sigma_w': self.Sigma_w, 'G_w': self.G_w,
-               'gf_struct': self.gf_struct, 'n_iw': self.n_iw, 'n_w': self.n_w,
-               'n_tau': self.n_tau, 'n_l': self.n_l,'beta': self.beta,
-               'w_min': self.w_min,'w_max': self.w_max,'ad':self.ad,
-               'idelta': self.idelta,'fops': self.fops,'eal':self.eal}
+        store_dict = {'G0_w': self.G0_w, 'G0_iw': self.G0_iw,'G_tau': self.G_tau,
+                      'G_l': self.G_l, 'Sigma_iw': self.Sigma_iw, 'G_iw': self.G_iw,
+                      'Sigma_w': self.Sigma_w, 'G_w': self.G_w,
+                      'gf_struct': self.gf_struct, 'n_iw': self.n_iw, 'n_w': self.n_w,
+                      'n_tau': self.n_tau, 'n_l': self.n_l,'beta': self.beta,
+                      'w_min': self.w_min,'w_max': self.w_max,
+                      'idelta': self.idelta,'fops': self.fops,'eal':self.eal}
+        if hasattr(self, 'ad'):
+            store_dict['ad'] = self.ad
+
+        return store_dict
 
     @classmethod
     def __factory_from_dict__(cls,name,D) :
-       
+
         instance = cls(D['beta'], D['gf_struct'], D['n_iw'], D['n_tau'],
                        D['n_l'], D['n_w'], D['w_min'], D['w_max'], D['idelta'])
-                      
-        instance.G0_w = D['G0_w'] 
-        instance.G0_iw = D['G0_iw'] 
-        instance.G_tau = D['G_tau'] 
-        instance.G_l = D['G_l'] 
-        instance.Sigma_iw = D['Sigma_iw'] 
-        instance.G_iw = D['G_iw'] 
-        instance.Sigma_w = D['Sigma_w'] 
-        instance.G_w = D['G_w'] 
+
+        instance.G0_w = D['G0_w']
+        instance.G0_iw = D['G0_iw']
+        instance.G_tau = D['G_tau']
+        instance.G_l = D['G_l']
+        instance.Sigma_iw = D['Sigma_iw']
+        instance.G_iw = D['G_iw']
+        instance.Sigma_w = D['Sigma_w']
+        instance.G_w = D['G_w']
         instance.gf_struct = fix_gf_struct_type(D['gf_struct'])
-        instance.fops = D['fops'] 
+        instance.fops = D['fops']
         instance.eal = D['eal']
         instance.ad = D['ad']
-       
+
         return instance
-    
-# registering my class                                                                                
+
+# registering my class
 from h5.formats import register_class
 register_class(Solver)

--- a/test/python/class_h5_read_write.py
+++ b/test/python/class_h5_read_write.py
@@ -37,14 +37,18 @@ S = Solver(beta = beta, gf_struct = [ ('up',1), ('down',1) ],idelta=0.5,n_iw=20,
 # set the non-interacting Green's function
 for name, g0 in S.G0_iw: g0 << inverse(iOmega_n - e_f - V**2 * Wilson(D))
 
+# Save the solver object before solving
+with HDFArchive("class.h5",'w') as Results:
+     Results["Solver"] = S
+
 # solve the atomic problem
 S.solve( h_int = U * n('up',0) * n('down',0) )
 
 # Save the results in an HDF5 file (only on the master node)
 with HDFArchive("class.h5",'w') as Results:
      Results["Solver"] = S
-     
-# Read the results from the reference HDF5 file 
+
+# Read the results from the reference HDF5 file
 with HDFArchive("class.ref.h5",'r') as Results:
      S_ref = Results["Solver"]
 


### PR DESCRIPTION
the solver object could not be stored if the `solve` command was not run first, because `self.ad` is only created when solve is called. The fix will add the `atomdiag` to the dict only if solve was called, otherwise not. 

Modified a test to check for this. 